### PR TITLE
VOL-2364 removed primaryEmailAddress

### DIFF
--- a/lib/rcrm/types/applicant/applicant.rb
+++ b/lib/rcrm/types/applicant/applicant.rb
@@ -48,7 +48,7 @@ module RCRM
     )
 
     def default_fields
-      %i(applicantId applicantName applicantSurname fileAs primaryEmailAddress)
+      %i(applicantId applicantName applicantSurname fileAs)
     end
   end
 end


### PR DESCRIPTION
Removed the primaryEmailAddress attribute from default fields as it isn't being filled in but defined in the request. Still required in the valid fields for the filter.